### PR TITLE
Vue graphique terminée

### DIFF
--- a/doted/app/Doted.py
+++ b/doted/app/Doted.py
@@ -37,4 +37,4 @@ class Doted(object):
 
     def run(self):
         '''Run the application.'''
-        self.mainWindow.showMaximized()
+        self.mainWindow.show()

--- a/doted/controller/Controller.py
+++ b/doted/controller/Controller.py
@@ -23,6 +23,15 @@ class Controller(Observer):
         self.view = view
         self.view.setController(self)
     
-    def update(self):
-        '''Update the view.'''
-        pass
+    def update(self, dictArgsNode, dictArgsEdge, updateModeView):
+        '''Update the view.
+        
+        Argument(s):
+        dictArgsNode (Dictionary[]): Dictionary of arguments of the node
+        dictArgsEdge (Dictionary[]): Dictionary of arguments of the edge
+        updateModeView (UpdateModeView) : Update mode
+        ''' 
+        if dictArgsNode: 
+            self.view.updateNode(dictArgsNode, updateModeView)
+        else:
+            self.view.updateEdge(dictArgsEdge, updateModeView)

--- a/doted/controller/GraphicsGraphController.py
+++ b/doted/controller/GraphicsGraphController.py
@@ -17,18 +17,6 @@ class GraphicsGraphController(Controller):
     def __init__(self, model, view):
         # Parent constructor(s)
         Controller.__init__(self, model, view)
-        
-    def update(self, dictArgsNode, dictArgsEdge):
-        '''Update the view.
-        
-        Argument(s):
-        dictArgsNode (Dictionary[]): dictionary of arguments of the node
-        dictArgsEdge (Dictionary[]): dictionary of arguments of the edge
-        ''' 
-        if dictArgsNode: 
-            self.view.updateNode(dictArgsNode)
-        else:
-            self.view.updateEdge(dictArgsEdge)
             
     def onCreateNode(self, x, y):
         '''Callback function when creating a node.
@@ -39,6 +27,23 @@ class GraphicsGraphController(Controller):
         '''
         self.model.addNode(x, y)
     
+    def onEditLabelNode(self, idNode, labelNode):
+        '''Callback function when editing a label a node.
+        
+        Argument(s):
+        idNode (int): ID of the node to edit
+        labelNode (str): New label of the node
+        '''
+        self.model.editLabelNode(idNode, labelNode)
+    
+    def onRemoveNode(self, idNode):
+        '''Callback function when removinf a node.
+        
+        Argument(s):
+        idNode (int): ID of the node to remove
+        '''
+        self.model.removeNode(idNode)
+    
     def onCreateEdge(self, idSourceNode, idDestNode):
         '''Callback function when creating an edge.
         
@@ -47,3 +52,11 @@ class GraphicsGraphController(Controller):
         idDestNode (int): ID of the destination node
         '''
         self.model.addEdge(idSourceNode, idDestNode)
+
+    def onRemoveEdge(self, idEdge):
+        '''Callback function when removing an edge.
+        
+        Argument(s):
+        idEdge (int): ID of the edge to remove
+        '''
+        self.model.removeEdge(idEdge)

--- a/doted/controller/MainWindowController.py
+++ b/doted/controller/MainWindowController.py
@@ -18,5 +18,12 @@ class MainWindowController(Controller):
         # Parent constructor(s)
         Controller.__init__(self, model, view)
 
-    def update(self, dictArgsNode, dictArgsEdge):
+    def update(self, dictArgsNode, dictArgsEdge, updateModeView):
+        '''Update the view.
+        
+        Argument(s):
+        dictArgsNode (Dictionary[]): Dictionary of arguments of the node
+        dictArgsEdge (Dictionary[]): Dictionary of arguments of the edge
+        updateModeView (UpdateModeView) : Update mode
+        ''' 
         pass

--- a/doted/controller/TextGraphController.py
+++ b/doted/controller/TextGraphController.py
@@ -17,15 +17,3 @@ class TextGraphController(Controller):
     def __init__(self, model, view):
         # Parent constructor(s)
         Controller.__init__(self, model, view)
-
-    def update(self, dictArgsNode, dictArgsEdge):
-        '''Update the view.
-        
-        Argument(s):
-        dictArgsNode (Dictionary[]): dictionary of arguments of the node
-        dictArgsEdge (Dictionary[]): dictionary of arguments of the edge
-        ''' 
-        if dictArgsNode: 
-            self.view.updateNode(dictArgsNode)
-        else:
-            self.view.updateEdge(dictArgsEdge)

--- a/doted/enumeration/EdgeArgs.py
+++ b/doted/enumeration/EdgeArgs.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class EdgeArgs(Enum):
+    '''The EdgeArgs enum defines the keys of the dictionary of an Edge.'''
+    id = 0
+    sourceId = 1
+    destId = 2

--- a/doted/enumeration/NodeArgs.py
+++ b/doted/enumeration/NodeArgs.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class NodeArgs(Enum):
+    '''The NodeArgs enum defines the keys of the dictionary of a Node.'''
+    id = 0
+    label = 1
+    x = 2
+    y = 3
+        

--- a/doted/enumeration/UpdateModeView.py
+++ b/doted/enumeration/UpdateModeView.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class UpdateModeView(Enum):
+    '''The UpdateModeView enum defines the mode when there is an update in a View.'''
+    add = 0
+    edit = 1
+    remove = 2

--- a/doted/model/Edge.py
+++ b/doted/model/Edge.py
@@ -1,20 +1,22 @@
 # -*- coding: utf-8 -*-
 
+from enumeration.EdgeArgs import EdgeArgs
 
-class Edge:
+
+class Edge(object):
     '''
     The Edge class defines an edge (model).
     
     
     Argument(s):
     source (Node): Source node
-    dest (Node): Destionation node
-    id (int): Id 
+    dest (Node): Destination node
+    id (int): ID
     
     Attribute(s):
     id (int): ID
     source (Node): Source node
-    dest (Node): Destionation node
+    dest (Node): Destination node
     '''
 
 
@@ -29,7 +31,7 @@ class Edge:
     def getArgs(self):
         '''Return a dictionary of the arguments of the edge.'''
         return {
-                "id": self.id,
-                "source": self.source,
-                "dest": self.dest
+                EdgeArgs.id: self.id,
+                EdgeArgs.sourceId: self.source.id,
+                EdgeArgs.destId: self.dest.id
             }

--- a/doted/model/Graph.py
+++ b/doted/model/Graph.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from observer.Subject import Subject
-from model.Node import Node
+from enumeration.UpdateModeView import UpdateModeView
 from model.Edge import Edge
+from model.Node import Node
+from observer.Subject import Subject
+
 
 class Graph(Subject):
     '''The Graph class defines a graph (model).
@@ -14,8 +16,8 @@ class Graph(Subject):
     Attribute(s):
     nodes (Dictionary[Node]): All nodes
     edges (Dictionary[Edge]): All edges
-    nbNodes (Dictionary[Edge]): number of nodes
-    nbEdges (Dictionary[Edge]): number of edges
+    nbNodes (Dictionary[Edge]): Number of nodes
+    nbEdges (Dictionary[Edge]): Number of edges
     directed (boolean): Graph directed or not
     '''
 
@@ -40,7 +42,7 @@ class Graph(Subject):
         self.nbNodes += 1
         node = Node(self.nbNodes, x , y)
         self.nodes[node.id] = node
-        self.notify(node.getArgs(), None);
+        self.notify(node.getArgs(), None, UpdateModeView.add)
     
     def removeNode(self, idNode):
         '''Remove a Node from the graph.
@@ -48,8 +50,31 @@ class Graph(Subject):
         Argument(s):
         idNode (int): ID of the node to remove
         '''
-        self.nodes.pop(idNode)
-    
+        node = self.nodes.pop(idNode)
+        self.notify(node.getArgs(), None, UpdateModeView.remove)
+
+        # Get the id of the egdes to remove
+        idEdgesToRemove = []
+        for edge in self.edges.values():
+            if (node == edge.source or node == edge.dest):
+                idEdgesToRemove.append(edge.id)
+        
+        # Remove associated edges
+        for idEdge in idEdgesToRemove:
+            self.removeEdge(idEdge)
+
+    def editLabelNode(self, idNode, labelNode):
+        '''Edit a label node of the graph.
+        
+        Argument(s):
+        idNode (int): ID of the node to edit
+        labelNode (str): New label node
+        '''
+        
+        node = self.nodes[idNode]
+        node.label = labelNode
+        self.notify(node.getArgs(), None, UpdateModeView.edit)
+        
     def addEdge(self, idSourceNode, idDestNode):
         '''Add an Edge to the graph and notify this.
         
@@ -60,10 +85,10 @@ class Graph(Subject):
         # Only add the edge if the two nodes are not neighboring
         if not self.nodes[idSourceNode].isNeighboringTo(idDestNode):
             self.nbEdges += 1
-            edge = Edge(self.nodes[idSourceNode],
-                                        self.nodes[idDestNode], self.nbEdges)
+            edge = Edge(self.nodes[idSourceNode], self.nodes[idDestNode],
+                        self.nbEdges)
             self.edges[edge.id] = edge
-            self.notify(None, edge.getArgs());
+            self.notify(None, edge.getArgs(), UpdateModeView.add)
     
     def removeEdge(self, idEdge):
         '''Remove an Edge from the graph.
@@ -71,14 +96,21 @@ class Graph(Subject):
         Argument(s):
         idEdge (int): ID of the edge to remove
         '''
-        self.edges.pop(idEdge)
+        edge = self.edges.pop(idEdge)
+        
+        # Source and dest nodes are not neighboring anymore
+        edge.source.removeNeighbour(edge.dest)
+        edge.dest.removeNeighbour(edge.source)
+        
+        self.notify(None, edge.getArgs(), UpdateModeView.remove)
        
-    def notify(self, dictArgsNode, dictArgsEdge):
+    def notify(self, dictArgsNode, dictArgsEdge, updateModeView):
         '''Notify all observers of the creation of a Node or an Edge.
         
         Argument(s):
-        dictArgsNode (Dictionary[]): dictionary of arguments of the node
-        dictArgsEdge (Dictionary[]): dictionary of arguments of the edge
+        dictArgsNode (Dictionary[]): Dictionary of arguments of the node
+        dictArgsEdge (Dictionary[]): Dictionary of arguments of the edge
+        updateModeView (UpdateModeView): Update mode
         '''
         for obs in self.observers:
-            obs.update(dictArgsNode, dictArgsEdge) 
+            obs.update(dictArgsNode, dictArgsEdge, updateModeView) 

--- a/doted/model/Node.py
+++ b/doted/model/Node.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from enumeration.NodeArgs import NodeArgs
 
-class Node:
+
+class Node(object):
     '''The Node class defines a node (model).
     
     
@@ -30,10 +32,23 @@ class Node:
         #self.color enum ?
         
     def addNeighbour(self, node):
+        '''Add a neighbour.
+        
+        Argument(s):
+        node (Node): Neighbour
+        '''
         self.neighbours[node.id] = node
+        
+    def removeNeighbour(self, node):
+        '''Remove a neighbour.
+        
+        Argument(s):
+        node (Node): Neighbour
+        '''
+        self.neighbours.pop(node.id)
 
     def isNeighboringTo(self, id):
-        '''Check is the the node is neighboring with another.
+        '''Check if the node is neighboring with another.
         
         Argument(s):
         id (int): Node id
@@ -43,8 +58,8 @@ class Node:
     def getArgs(self):
         '''Return a dictionary of the arguments of the node.'''
         return {
-                "id": self.id,
-                "label": self.label,
-                "x": self.x,
-                "y": self.y
+                NodeArgs.id: self.id,
+                NodeArgs.label: self.label,
+                NodeArgs.x: self.x,
+                NodeArgs.y: self.y
             }

--- a/doted/view/edge/EdgeUtils.py
+++ b/doted/view/edge/EdgeUtils.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+
+class EdgeUtils(object):
+    '''The EdgeUtils class defines a set of functions to work on edges.'''
+    
+    @staticmethod
+    def closestPointTo(point, path):
+        '''Return the closest point between a point and a path.
+        
+        Argument(s):
+        point (QPointF): Point
+        path (QPainterPath): Painter path
+        '''
+        target = path.boundingRect().center()
+        mid = (point + target) / 2.0
+        
+        if path.contains(mid):
+            return mid
+        else:
+            while (mid - point).manhattanLength() > 1:
+                while not path.contains(mid) :
+                    point = mid
+                    mid = (point + target) / 2.0
+    
+                while path.contains(mid) :
+                    mid = (point + mid) / 2.0
+                    
+            return mid

--- a/doted/view/edge/GraphicsEdge.py
+++ b/doted/view/edge/GraphicsEdge.py
@@ -8,36 +8,16 @@ class GraphicsEdge(object):
     Argument(s):
     source (GraphicsNode): Node view
     dest (GraphicsNode): Node view
+    id (int): ID
     
     Attribute(s):
     source (GraphicsNode): Node view
     dest (GraphicsNode): Node view
+    id (int): ID
     '''
 
 
-    def __init__(self, source, dest):
+    def __init__(self, source, dest, id):
         self.source = source
         self.dest = dest
-        
-    def closestPointTo(self, point, path):
-        '''Return the closest point between a point and a path.
-        
-        Argument(s):
-        point (QPointF): Point
-        path (QPainterPath): Painter path
-        '''
-        target = path.boundingRect().center()
-        mid = (point + target) / 2.0
-        
-        if path.contains(mid):
-            return mid
-        else:
-            while (mid - point).manhattanLength() > 1:
-                while not path.contains(mid) :
-                    point = mid
-                    mid = (point + target) / 2.0
-    
-                while path.contains(mid) :
-                    mid = (point + mid) / 2.0
-                    
-            return mid
+        self.id = id

--- a/doted/view/edge/GraphicsLineEdge.py
+++ b/doted/view/edge/GraphicsLineEdge.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from PyQt5.Qt import QLineF
 from PyQt5.QtWidgets import QGraphicsLineItem, QGraphicsItem
 
+from view.edge.EdgeUtils import EdgeUtils
 from view.edge.GraphicsEdge import GraphicsEdge
 
 
@@ -13,23 +13,29 @@ class GraphicsLineEdge(GraphicsEdge, QGraphicsLineItem):
     Argument(s):
     source (GraphicsNode): Node view
     dest (GraphicsNode): Node view
+    id (int): ID
     '''
 
 
-    def __init__(self, source, dest):
+    def __init__(self, source, dest, id):
         # Parent constructor(s)
-        GraphicsEdge.__init__(self, source, dest)
+        GraphicsEdge.__init__(self, source, dest, id)
         QGraphicsLineItem.__init__(self)
         
+        self.setFlag(QGraphicsItem.ItemIsSelectable)        
+        self.update()
+
+    def update(self):
+        '''Update the coordinates of the line.'''
         # Get the two shapes of each node
         sourceShape = self.source.mapToScene(self.source.shape())
         destShape = self.dest.mapToScene(self.dest.shape())
         
         # Compute the closest points between the two shapes
-        pSource = self.closestPointTo(destShape.boundingRect().center(),
-                                      sourceShape)
-        pDest = self.closestPointTo(sourceShape.boundingRect().center(),
-                                    destShape)
+        pSource = EdgeUtils.closestPointTo(destShape.boundingRect().center(),
+                                           sourceShape)
+        pDest = EdgeUtils.closestPointTo(sourceShape.boundingRect().center(),
+                                         destShape)
         
-        self.setLine(QLineF(pSource, pDest))
-        self.setFlag(QGraphicsItem.ItemIsSelectable)
+        # Draw a line between source and dest
+        self.setLine(pSource.x(), pSource.y(), pDest.x(), pDest.y())

--- a/doted/view/edge/GraphicsSemiEdge.py
+++ b/doted/view/edge/GraphicsSemiEdge.py
@@ -2,11 +2,12 @@
 
 from PyQt5.QtWidgets import QGraphicsLineItem
 
-from view.edge.GraphicsEdge import GraphicsEdge
+from view.edge.EdgeUtils import EdgeUtils
 
 
-class GraphicsSemiEdge(GraphicsEdge, QGraphicsLineItem):
-    '''The GraphicsSemiEdge class defines a line between a GraphicsNode and a QPoint. 
+class GraphicsSemiEdge(QGraphicsLineItem):
+    '''The GraphicsSemiEdge class defines a line between a GraphicsNode and a
+       QPoint. 
     
     
     Argument(s):
@@ -17,8 +18,10 @@ class GraphicsSemiEdge(GraphicsEdge, QGraphicsLineItem):
 
     def __init__(self, source, dest):
         # Parent constructor(s)
-        GraphicsEdge.__init__(self, source, dest)
         QGraphicsLineItem.__init__(self)
+        
+        self.source = source
+        self.dest = dest
     
     def update(self, source):
         '''Update the coordinates of the line.
@@ -27,6 +30,6 @@ class GraphicsSemiEdge(GraphicsEdge, QGraphicsLineItem):
         source (QPointF): Source point
         '''
         destShape = self.dest.mapToScene(self.dest.shape())
-        p = self.closestPointTo(source, destShape)
+        p = EdgeUtils.closestPointTo(source, destShape)
         
         self.setLine(source.x(), source.y(), p.x(), p.y())

--- a/doted/view/node/GraphicsEllipseNode.py
+++ b/doted/view/node/GraphicsEllipseNode.py
@@ -1,23 +1,20 @@
 # -*- coding: utf-8 -*-
 
 from PyQt5.Qt import QMarginsF, Qt
-from PyQt5.QtWidgets import QGraphicsEllipseItem, QGraphicsItem, QApplication
+from PyQt5.QtWidgets import QGraphicsEllipseItem, QGraphicsItem
 
 from view.edge.GraphicsSemiEdge import GraphicsSemiEdge
 from view.node.GraphicsNode import GraphicsNode
 
 
 class GraphicsEllipseNode(GraphicsNode, QGraphicsEllipseItem):
-    '''The GraphicsEllipseNode defines a graphics node as an ellipse containing
-       a text.
+    '''The GraphicsEllipseNode class defines a graphics node as an ellipse 
+       containing a text.
     
     
     Argument(s):
-    id (int): Id of the node
+    id (int): ID of the node
     label (str): Label of the node
-    
-    Attribute(s):
-    semiEdge (GraphicsSemiEdge): Line between graphics node and mouse
     '''
 
 
@@ -26,12 +23,12 @@ class GraphicsEllipseNode(GraphicsNode, QGraphicsEllipseItem):
         GraphicsNode.__init__(self, id, label)
         QGraphicsEllipseItem.__init__(self)
         
+        # Init text node
         self.graphicsTextNode.setParentItem(self)
         self.setFlags(QGraphicsItem.ItemIsMovable |
                       QGraphicsItem.ItemIsSelectable)
-        
         self.centerTextInShape()
-        self.semiEdge = None
+    
 
     def centerTextInShape(self):
         '''Center the text in the ellipse.'''
@@ -39,35 +36,29 @@ class GraphicsEllipseNode(GraphicsNode, QGraphicsEllipseItem):
                           marginsAdded(QMarginsF(10, 10, 10, 10)))
         
     def mouseMoveEvent(self, event):
-        '''Event handler when moving the graphics node.
+        '''Handle mouse move event.
         
         Argument(s):
-        event (QGraphicsSceneMouseEvent): Event
-        '''
-        modifiers = QApplication.keyboardModifiers()
+        event (QGraphicsSceneMouseEvent): Graphics scene mouse event
+        '''        
         # Move the node
-        if modifiers == Qt.ControlModifier:
-            return QGraphicsEllipseItem.mouseMoveEvent(self, event)
+        if event.modifiers() == Qt.ControlModifier:
+            QGraphicsEllipseItem.mouseMoveEvent(self, event)
+            
+            # Update coordinates of each edge of the current node
+            self.getGraphicsView().updateEdgesOfNode(self)
         
         # Update coordinates of the line
         if self.semiEdge is not None:
             self.semiEdge.update(event.scenePos())
     
     def mousePressEvent(self, event):
-        '''Event handler when clicking on the graphics node.
+        '''Handle mouse press event.
         
         Argument(s):
-        event (QGraphicsSceneMouseEvent): Event
+        event (QGraphicsSceneMouseEvent): Graphics scene mouse event
         '''
         QGraphicsEllipseItem.mousePressEvent(self, event)
-        modifiers = QApplication.keyboardModifiers()
-        
-        # Deselect all items then select itself
-        if modifiers == Qt.ControlModifier:
-            for item in self.scene().selectedItems():
-                item.setSelected(False)
-            self.setSelected(True)
-            return
 
         # Create the semi-edge
         if event.buttons() == Qt.LeftButton:
@@ -75,16 +66,16 @@ class GraphicsEllipseNode(GraphicsNode, QGraphicsEllipseItem):
             self.scene().addItem(self.semiEdge)
         
     def mouseReleaseEvent(self, event):
-        '''Event handler when releasing the mouse button.
+        '''Handle mouse release event.
         
         Argument(s):
-        event (QGraphicsSceneMouseEvent): Event
+        event (QGraphicsSceneMouseEvent): Graphics scene mouse event
         '''
         QGraphicsEllipseItem.mouseReleaseEvent(self, event)
         
-        # Need to check else it is possible to create an edge with right click
+        # Construct edge if a semi edge is built
         if self.semiEdge is not None:
-            # Remove the semi-edge
+            # Remove the semi edge
             self.scene().removeItem(self.semiEdge)
             self.semiEdge = None
          
@@ -92,6 +83,15 @@ class GraphicsEllipseNode(GraphicsNode, QGraphicsEllipseItem):
             items = [item for item in self.scene().items(event.scenePos())
                      if isinstance(item, GraphicsNode) and item != self]
             if items:
-                # Get the controller of the view, no need to check index
-                controller = self.scene().views()[0].controller
-                controller.onCreateEdge(self.id, items[0].id)
+                # Create edge
+                self.getGraphicsView().controller.onCreateEdge(self.id,
+                                                               items[0].id)
+                
+    def mouseDoubleClickEvent(self, event):
+        '''Handle mouse double click event.
+        
+        Argument(s):
+        event (QGraphicsSceneMouseEvent): Graphics scene mouse event
+        '''
+        # Double click on the text of the node to edit text
+        self.graphicsTextNode.mouseDoubleClickEvent(event)

--- a/doted/view/node/GraphicsNode.py
+++ b/doted/view/node/GraphicsNode.py
@@ -13,17 +13,26 @@ class GraphicsNode(object):
     label (str): Label of the node
     
     Attribute(s):
-    id (int): Id of the node
+    id (int): ID of the node
     graphicsTextNode (GraphicsTextNode): Text (label) of the node
+    semiEdge (GraphicsSemiEdge): Line between a graphics node and cursor mouse
     '''
 
 
     def __init__(self, id, label):
         self.id = id;
+        
+        # Init graphics text node
         self.graphicsTextNode = GraphicsTextNode(label);
         (self.graphicsTextNode.boundingRect().
                                marginsAdded(QMarginsF(10, 10, 10, 10)))
+        
+        self.semiEdge = None
     
     def centerTextInShape(self):
         '''Center the text in the shape.'''
         pass
+
+    def getGraphicsView(self):
+        '''Return the graphics view.'''
+        return self.scene().views()[0]

--- a/doted/view/node/GraphicsTextNode.py
+++ b/doted/view/node/GraphicsTextNode.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from PyQt5.QtCore import Qt
+from PyQt5.Qt import Qt
 from PyQt5.QtWidgets import QGraphicsTextItem
 
 
 class GraphicsTextNode(QGraphicsTextItem):
     '''The GraphicsTextNode class defines the text of a GraphicsNode.
-    
-    
+
+
     Argument(s):
     label (str): Label of the node
     '''
@@ -16,14 +16,59 @@ class GraphicsTextNode(QGraphicsTextItem):
     def __init__(self, label):
         # Parent constructor(s)
         QGraphicsTextItem.__init__(self, label)
-        
-        self.setTextInteractionFlags(Qt.TextEditorInteraction)
-    
+
     def keyPressEvent(self, event):
-        '''Center the text in the shape each time the text is modified.
-        
+        '''Handle key pressed event.
+
         Argument(s):
         event (QKeyEvent): Key event
         '''
         QGraphicsTextItem.keyPressEvent(self, event)
+        
+        # Must center the text in the shape
         self.parentItem().centerTextInShape()
+        
+        # Update coordinates of each edge of the current node
+        graphicsNode = self.parentItem()
+        graphicsNode.getGraphicsView().updateEdgesOfNode(graphicsNode)
+  
+
+    def mouseDoubleClickEvent(self, event):
+        '''Handle mouse double click event.
+
+        Argument(s):
+        event (QGraphicsSceneMouseEvent): Graphics scene mouse event
+        '''
+        QGraphicsTextItem.mouseDoubleClickEvent(self, event)
+        
+        # Enable edit text
+        self.setTextInteractionFlags(Qt.TextEditorInteraction)
+        
+        # Go to edit mode text
+        self.setFocus()        
+
+    def focusOutEvent(self, event):
+        '''Handle focus out event.
+
+        Argument(s):
+        event (QFocusEvent ): Focus event
+        '''
+        QGraphicsTextItem.focusOutEvent(self, event)
+        
+        # Update text in other views
+        node = self.parentItem()
+        node.getGraphicsView().controller.onEditLabelNode(node.id,
+                                                          self.toPlainText())
+        
+        # Disable edit text
+        self.setTextInteractionFlags(Qt.NoTextInteraction)
+        
+    def contextMenuEvent(self, event):
+        '''Handle context menu event.
+        
+        Argument(s):
+        event (QGraphicsSceneContextMenuEvent): Graphics scene context menu 
+                                                event
+        '''
+        # Disable context menu (right click)
+        pass

--- a/doted/view/widget/TextGraphView.py
+++ b/doted/view/widget/TextGraphView.py
@@ -2,6 +2,9 @@
 
 from PyQt5.QtWidgets import QTextEdit
 
+from enumeration.NodeArgs import NodeArgs
+from enumeration.UpdateModeView import UpdateModeView
+from enumeration.EdgeArgs import EdgeArgs
 from view.widget.View import View
 
 
@@ -13,6 +16,9 @@ class TextGraphView(View, QTextEdit):
     Attribute(s):
     nodes (Dictionary[GraphicNode]): All nodes (views)
     edges (Dictionary[GraphicEdge]): All edges (views)
+    strNodes (str): Text for nodes
+    textEdges (str): Text for edges
+    graphName (str): Name of the graph
     '''
 
 
@@ -23,27 +29,74 @@ class TextGraphView(View, QTextEdit):
                 
         self.nodes = {}
         self.edges = {}
+        
+        self.strNodes = ""
+        self.strEdges = ""
+        self.graphName = "my_graph"
 
-    def updateNode(self, dictArgsNode):
+    def updateNode(self, dictArgsNode, updateModeView):
         '''Create or update a node (in the text).
         
         
         Argument(s):
         dictArgsNode (Dictionary[]): dictionary of arguments of the node
+        updateModeView (UpdateModeView) : Update mode
         '''
-        nodeId = dictArgsNode["id"]
-        self.nodes[nodeId] = dictArgsNode["label"]
+        id = dictArgsNode[NodeArgs.id]
         
-        # The way of displaying will change
-        stringNodes = ""
-        for id, label in self.nodes.items():
-            stringNodes += str(id) + " [label=\"" + label + "\"] ;\n"
-        self.setPlainText(stringNodes)
+        # Add node
+        if updateModeView == UpdateModeView.add:
+            self.nodes[id] = dictArgsNode[NodeArgs.label]
+        
+        # Edit node
+        elif updateModeView == UpdateModeView.edit:
+            self.nodes[id] = dictArgsNode[NodeArgs.label]
+        
+        # Remove node
+        elif updateModeView == UpdateModeView.remove:
+            self.nodes.pop(id)
+        
+        # Generate string nodes
+        self.strNodes = ""
+        for idNode, labelNode in self.nodes.items():
+            self.strNodes += ("    " + str(idNode) +
+                              " [label=\"" + labelNode.replace('\n', '') +
+                              "\"] ;\n")
+        
+        self.setPlainText(self.strDot())
 
-    def updateEdge(self, dictArgsEdge):
+    def updateEdge(self, dictArgsEdge, updateModeView):
         '''Create or update an edge (on the scene).
         
         Argument(s):
         dictArgsEdge (Dictionary[]): dictionary of arguments of the edge
+        updateModeView (UpdateModeView) : Update mode
         '''
-        pass
+        id = dictArgsEdge[EdgeArgs.id]
+        
+        # Add edge
+        if updateModeView == UpdateModeView.add:
+            self.edges[id] = (dictArgsEdge[EdgeArgs.sourceId],
+                              dictArgsEdge[EdgeArgs.destId])
+        
+        # Edit edge
+        elif updateModeView == UpdateModeView.edit:
+            pass
+        
+        # Remove edge
+        elif updateModeView == UpdateModeView.remove:
+            self.edges.pop(id)
+        
+        # Generate string edges
+        self.strEdges = ""
+        for tupleIdNodes in self.edges.values():
+            self.strEdges += ("    " + str(tupleIdNodes[0]) + "-" +
+                              str(tupleIdNodes[1]) + "\n")
+        
+        self.setPlainText(self.strDot())
+    
+    def strDot(self):
+        '''Return the dot string representation of the graph.'''
+        return ("graph " + self.graphName + " {\n" +
+                self.strNodes + self.strEdges +
+                "}")

--- a/doted/view/widget/View.py
+++ b/doted/view/widget/View.py
@@ -21,6 +21,21 @@ class View(object):
         '''
         self.controller = controller
 
-    def update(self):
-        '''Update the view.'''
+    def updateNode(self, dictArgsNode, updateMode):
+        '''Update a node (on the scene).
+        
+        Argument(s):
+        dictArgsNode (Dictionary[]): Dictionary of arguments of the node
+        updateMode (UpdateMode) : Update mode
+        '''
+        pass
+            
+            
+    def updateEdge(self, dictArgsEdge, updateMode):
+        '''Update an edge (on the scene).
+        
+        Argument(s):
+        dictArgsEdge (Dictionary[]): Dictionary of arguments of the edge
+        updateMode (UpdateMode) : Update mode
+        '''
         pass


### PR DESCRIPTION
- Déplacement d'un nœud possible même en (CTRL +) cliquant sur son le label.
- Édition d'un label d'un nœud en faisait un double clic.
- Le label se met à jour quand on perd le focus.
- Positions des arrêtes mises à jour lors de l'édition/déplacement d'un nœud.
- Suppression des nœuds/arrêtes possibles.
- Affichage des arrêtes dans la vue textuelle (la méthode va surement changer, c'était surtout pour voir que tout était bien lié lors d'un ajout/édition/suppression).

Nous avons donc terminé la vue graphique (mis à part les formes et couleurs éléments graphiques).
